### PR TITLE
search/clear button visibility fixes

### DIFF
--- a/d2l-search-input.html
+++ b/d2l-search-input.html
@@ -116,19 +116,21 @@ Polymer-based web components for search
 				disabled$="[[disabled]]"
 				maxlength$="[[maxlength]]"
 				on-keypress="_handleInputKeyPress"
+				on-input="_handleInput"
 				placeholder$="[[placeholder]]"
-				type="text" value="[[value]]" />
+				type="text"
+				value="[[value]]" />
 			<d2l-button-icon
 				class="d2l-search-input-search"
 				disabled$="[[disabled]]"
-				hidden=[[value]]
+				hidden=[[!_showSearch]]
 				icon="d2l-tier1:search"
 				on-click="_handleSearchClick"
 				text="[[localize('search')]]"></d2l-button-icon>
 			<d2l-button-icon
 				class="d2l-search-input-clear"
 				disabled$="[[disabled]]"
-				hidden=[[!value]]
+				hidden=[[_showSearch]]
 				icon="d2l-tier1:close-default"
 				on-click="_handleClearClick"
 				text="[[localize('search.clear')]]"></d2l-button-icon>
@@ -177,7 +179,19 @@ Polymer-based web components for search
 				value: {
 					type: String,
 					notify: true,
-					reflectToAttribute: true
+					value: ''
+				},
+				/**
+				 * Value of the input the last time a search was performed.
+				 */
+				lastSearchValue: {
+					type: String,
+					readOnly: true,
+					value: ''
+				},
+				_showSearch: {
+					type: Boolean,
+					computed: '_computeShowSearch(lastSearchValue, value)'
 				}
 			},
 
@@ -186,6 +200,9 @@ Polymer-based web components for search
 			},
 
 			ready: function() {
+				if (this.value !== undefined && this.value !== null) {
+					this._setLastSearchValue(this.value);
+				}
 				this._handleFocus = this._handleFocus.bind(this);
 				this._handleBlur = this._handleBlur.bind(this);
 				this._handleMouseEnter = this._handleMouseEnter.bind(this);
@@ -208,6 +225,14 @@ Polymer-based web components for search
 				elem.removeEventListener('blur', this._handleBlur, true);
 				elem.removeEventListener('mouseenter', this._handleMouseEnter, true);
 				elem.removeEventListener('mouseleave', this._handleMouseLeave, true);
+			},
+
+			_computeShowSearch: function(lastSearchValue, value) {
+				var valueIsEmpty = (value === undefined || value === null || value === '');
+				var lastSearchValueIsEmpty = (lastSearchValue === undefined || lastSearchValue === null || lastSearchValue === '');
+				var showSearch = (valueIsEmpty && lastSearchValueIsEmpty) ||
+					(lastSearchValue !== value);
+				return showSearch;
 			},
 
 			_dispatchEvent: function() {
@@ -244,15 +269,12 @@ Polymer-based web components for search
 			},
 
 			_handleClearClick: function() {
+				this.value = '';
+				this._setLastSearchValue('');
+				this._dispatchClearEvent();
 				fastdom.mutate(function() {
 					var input = Polymer.dom(this.root).querySelector('input');
-					this.value = '';
-					fastdom.measure(function() {
-						fastdom.mutate(function() {
-							input.focus();
-						});
-					});
-					this._dispatchClearEvent();
+					input.focus();
 				}.bind(this));
 			},
 
@@ -269,8 +291,13 @@ Polymer-based web components for search
 				var value = e.target.value;
 				fastdom.mutate(function() {
 					this.value = value;
+					this._setLastSearchValue(value);
 					this._dispatchEvent();
 				}.bind(this));
+			},
+
+			_handleInput: function(e) {
+				this.value = e.target.value;
 			},
 
 			_handleMouseEnter: function() {
@@ -287,13 +314,14 @@ Polymer-based web components for search
 			},
 
 			_handleSearchClick: function() {
+				var input = Polymer.dom(this.root).querySelector('input');
+				this.value = input.value;
+				this._setLastSearchValue(input.value);
+				this._dispatchEvent();
 				fastdom.mutate(function() {
-					var input = Polymer.dom(this.root).querySelector('input');
-					this.value = input.value;
 					if (this.value.length > 0) {
 						Polymer.dom(this.root).querySelector('.d2l-search-input-clear').focus();
 					}
-					this._dispatchEvent();
 				}.bind(this));
 			},
 

--- a/test/d2l-search-input.html
+++ b/test/d2l-search-input.html
@@ -6,6 +6,7 @@
 		<title>d2l-search-input test</title>
 		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../web-component-tester/browser.js"></script>
+		<link rel="import" href="../../iron-test-helpers/mock-interactions.html">
 		<link rel="import" href="../d2l-search-input.html">
 	</head>
 	<body>
@@ -23,11 +24,159 @@
 			describe('<d2l-search-input>', function() {
 
 				it('should properly instantiate the element', function() {
-					var element = fixture('basic');
-					assert.equal(element.is, 'd2l-search-input');
+					var elem = fixture('basic');
+					expect(elem.is).to.equal('d2l-search-input');
+				});
+
+				describe('value and lastSearchValue', function() {
+
+					it('should default both to empty string', function() {
+						var elem = fixture('basic');
+						expect(elem.value).to.equal('');
+						expect(elem.lastSearchValue).to.equal('');
+					});
+
+					it('should initially match lastSearchValue with value', function() {
+						var elem = fixture('value-set');
+						expect(elem.value).to.equal('foo');
+						expect(elem.lastSearchValue).to.equal('foo');
+					});
+
+					it('should not persist value to lastSearchValue', function() {
+						var elem = fixture('basic');
+						elem.value = 'bar';
+						expect(elem.lastSearchValue).to.equal('');
+					});
+
+					it('should persist value to lastSearchValue when search is performed', function() {
+						var elem = fixture('basic');
+						elem.value = 'bar';
+						clickSearchButton(elem);
+						expect(elem.value).to.equal('bar');
+						expect(elem.lastSearchValue).to.equal('bar');
+					});
+
+					it('should clear both when cleared', function() {
+						var elem = fixture('value-set');
+						clickClearButton(elem);
+						expect(elem.value).to.equal('');
+						expect(elem.lastSearchValue).to.equal('');
+					});
+
+				});
+
+				describe('search & clear button visibility', function() {
+
+					it('should show search if no value is set', function() {
+						var elem = fixture('basic');
+						assertSearchVisibility(elem, true);
+					});
+
+					[undefined, null, ''].forEach(function(val) {
+						it(`should show search if "${val}" value is set`, function() {
+							var elem = fixture('basic');
+							elem.value = val;
+							assertSearchVisibility(elem, true);
+						});
+					});
+
+					it('should show clear if a value is set', function() {
+						var elem = fixture('value-set');
+						assertSearchVisibility(elem, false);
+					});
+
+					it('should show search if value is modified', function() {
+						var elem = fixture('value-set');
+						elem.value = 'foobar';
+						assertSearchVisibility(elem, true);
+					});
+
+					it('should show search if value is cleared', function() {
+						var elem = fixture('value-set');
+						clickClearButton(elem);
+						assertSearchVisibility(elem, true);
+					});
+
+					it('should show search if empty search is performed', function() {
+						var elem = fixture('basic');
+						clickSearchButton(elem);
+						assertSearchVisibility(elem, true);
+					});
+
+					it('should show clear if modified value is searched', function() {
+						var elem = fixture('value-set');
+						elem.value = 'foobar';
+						clickSearchButton(elem);
+						assertSearchVisibility(elem, false);
+					});
+
+				});
+
+				describe('events', function() {
+
+					it('should fire "search" event when search is performed', function(done) {
+						var elem = fixture('basic');
+						elem.addEventListener('d2l-search-input-search', function() {
+							done();
+						});
+						elem.addEventListener('d2l-search-input-clear', function() {
+							throw 'Unexpected clear event';
+						});
+						elem.value = 'bar';
+						clickSearchButton(elem);
+					});
+
+					it('should fire "clear" event when cleared', function(done) {
+						var elem = fixture('value-set');
+						elem.addEventListener('d2l-search-input-search', function() {
+							throw 'Unexpected search event';
+						});
+						elem.addEventListener('d2l-search-input-clear', function() {
+							done();
+						});
+						clickClearButton(elem);
+					});
+
+					it('should fire "clear" event empty value search', function(done) {
+						var elem = fixture('basic');
+						elem.addEventListener('d2l-search-input-search', function() {
+							throw 'Unexpected search event';
+						});
+						elem.addEventListener('d2l-search-input-clear', function() {
+							done();
+						});
+						clickSearchButton(elem);
+					});
+
 				});
 
 			});
+
+			function assertSearchVisibility(elem, isVisible) {
+				if (isVisible) {
+					expect(getClearButton(elem).hasAttribute('hidden')).to.be.true;
+					expect(getSearchButton(elem).hasAttribute('hidden')).to.be.false;
+				} else {
+					expect(getClearButton(elem).hasAttribute('hidden')).to.be.false;
+					expect(getSearchButton(elem).hasAttribute('hidden')).to.be.true;
+				}
+			}
+
+			function clickClearButton(elem) {
+				MockInteractions.tap(getClearButton(elem));
+			}
+
+			function clickSearchButton(elem) {
+				MockInteractions.tap(getSearchButton(elem));
+			}
+
+			function getSearchButton(elem) {
+				return Polymer.dom(elem.root).querySelector('.d2l-search-input-search');
+			}
+
+			function getClearButton(elem) {
+				return Polymer.dom(elem.root).querySelector('.d2l-search-input-clear');
+			}
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
Major changes here:
- Showing and hiding the search and clear buttons based on the current value. So when you change the value, the search button appears. When it goes back to the original value or after a search, clear appears.
- Introduces `lastSearchValue` as a readonly property so we can track what the last searched for value was.
- `value` will always exactly match what's in the input, instead of only being updated when search or clear is pressed. It no longer reflects to the attribute though, which matches how native inputs behave.
- Tests