### PR TITLE
combine search and clear events and only fire event when value changed

### DIFF
--- a/d2l-search-input.html
+++ b/d2l-search-input.html
@@ -146,6 +146,12 @@ Polymer-based web components for search
 				D2L.PolymerBehaviors.Search.LocalizeBehavior
 			],
 
+			/**
+			 * Fired when a search or clear is performed.
+			 * @event d2l-search-input-search
+			 * @param {String} value Value of the search input.
+			 */
+
 			properties: {
 				/**
 				 * Whether the input is disabled.
@@ -236,24 +242,9 @@ Polymer-based web components for search
 			},
 
 			_dispatchEvent: function() {
-				if (this.value.length > 0) {
-					this._dispatchSearchEvent(this.value);
-				} else {
-					this._dispatchClearEvent();
-				}
-			},
-
-			_dispatchSearchEvent: function(value) {
 				this.dispatchEvent(new CustomEvent(
 					'd2l-search-input-search',
-					{bubbles: true, composed: false, detail: {value: value}}
-				));
-			},
-
-			_dispatchClearEvent: function() {
-				this.dispatchEvent(new CustomEvent(
-					'd2l-search-input-clear',
-					{bubbles: true, composed: false, detail: {value: ''}}
+					{bubbles: true, composed: false, detail: {value: this.value}}
 				));
 			},
 
@@ -270,8 +261,10 @@ Polymer-based web components for search
 
 			_handleClearClick: function() {
 				this.value = '';
-				this._setLastSearchValue('');
-				this._dispatchClearEvent();
+				if (this.value !== this.lastSearchValue) {
+					this._setLastSearchValue('');
+					this._dispatchEvent();
+				}
 				fastdom.mutate(function() {
 					var input = Polymer.dom(this.root).querySelector('input');
 					input.focus();
@@ -288,12 +281,10 @@ Polymer-based web components for search
 				if (e.keyCode !== this._keyCodes.ENTER) {
 					return;
 				}
-				var value = e.target.value;
-				fastdom.mutate(function() {
-					this.value = value;
-					this._setLastSearchValue(value);
+				if (this.value !== this.lastSearchValue) {
+					this._setLastSearchValue(this.value);
 					this._dispatchEvent();
-				}.bind(this));
+				}
 			},
 
 			_handleInput: function(e) {
@@ -314,10 +305,10 @@ Polymer-based web components for search
 			},
 
 			_handleSearchClick: function() {
-				var input = Polymer.dom(this.root).querySelector('input');
-				this.value = input.value;
-				this._setLastSearchValue(input.value);
-				this._dispatchEvent();
+				if (this.value !== this.lastSearchValue) {
+					this._setLastSearchValue(this.value);
+					this._dispatchEvent();
+				}
 				fastdom.mutate(function() {
 					if (this.value.length > 0) {
 						Polymer.dom(this.root).querySelector('.d2l-search-input-clear').focus();

--- a/test/d2l-search-input.html
+++ b/test/d2l-search-input.html
@@ -114,38 +114,61 @@
 
 				describe('events', function() {
 
-					it('should fire "search" event when search is performed', function(done) {
+					it('should fire "search" event when search button is clicked', function(done) {
 						var elem = fixture('basic');
-						elem.addEventListener('d2l-search-input-search', function() {
+						elem.addEventListener('d2l-search-input-search', function(e) {
+							expect(e.detail.value).to.equal('bar');
 							done();
-						});
-						elem.addEventListener('d2l-search-input-clear', function() {
-							throw 'Unexpected clear event';
 						});
 						elem.value = 'bar';
 						clickSearchButton(elem);
 					});
 
-					it('should fire "clear" event when cleared', function(done) {
-						var elem = fixture('value-set');
-						elem.addEventListener('d2l-search-input-search', function() {
-							throw 'Unexpected search event';
+					it('should fire "search" event when ENTER is pressed', function(done) {
+						var elem = fixture('basic');
+						elem.addEventListener('d2l-search-input-search', function(e) {
+							expect(e.detail.value).to.equal('bar');
+							done();
 						});
-						elem.addEventListener('d2l-search-input-clear', function() {
+						elem.value = 'bar';
+						pressEnter(elem);
+					});
+
+					it('should fire "search" event when clear button is pressed', function(done) {
+						var elem = fixture('value-set');
+						elem.addEventListener('d2l-search-input-search', function(e) {
+							expect(e.detail.value).to.equal('');
 							done();
 						});
 						clickClearButton(elem);
 					});
 
-					it('should fire "clear" event empty value search', function(done) {
+					it('should fire "search" event on empty value search', function(done) {
+						var elem = fixture('value-set');
+						elem.addEventListener('d2l-search-input-search', function(e) {
+							expect(e.detail.value).to.equal('');
+							done();
+						});
+						elem.value = '';
+						clickSearchButton(elem);
+					});
+
+					it('should not fire "search" event when ENTER is pressed with no value change', function(done) {
+						var elem = fixture('value-set');
+						elem.addEventListener('d2l-search-input-search', function() {
+							throw 'Unexpected search event';
+						});
+						pressEnter(elem);
+						setTimeout(done, 50);
+					});
+
+					it('should not fire "search" event when search button is pressed on empty value', function(done) {
 						var elem = fixture('basic');
 						elem.addEventListener('d2l-search-input-search', function() {
 							throw 'Unexpected search event';
 						});
-						elem.addEventListener('d2l-search-input-clear', function() {
-							done();
-						});
 						clickSearchButton(elem);
+						setTimeout(done, 50);
 					});
 
 				});
@@ -176,6 +199,11 @@
 
 			function getClearButton(elem) {
 				return Polymer.dom(elem.root).querySelector('.d2l-search-input-clear');
+			}
+
+			function pressEnter(elem) {
+				var input = Polymer.dom(elem.root).querySelector('input');
+				MockInteractions.keyEventOn(input, 'keypress', elem._keyCodes.ENTER);
 			}
 		</script>
 	</body>


### PR DESCRIPTION
As discussed, a couple changes here:
- Combines the search and clear events into a single event
- Only fires the event if the value has actually changed from the last time a search (or clear) was performed. This prevents multiple events from firing when you hit ENTER multiple times on the same value.