### PR TITLE
moving event listeners to the host element

### DIFF
--- a/d2l-search-input.html
+++ b/d2l-search-input.html
@@ -20,11 +20,8 @@ Polymer-based web components for search
 
 			:host {
 				display: inline-block;
-				width: 100%
-			}
-
-			.d2l-search-input-container {
 				position: relative;
+				width: 100%
 			}
 
 			input {
@@ -109,7 +106,7 @@ Polymer-based web components for search
 			}
 
 		</style>
-		<div role="search" class="d2l-search-input-container">
+		<div class="d2l-search-input-container">
 			<input
 				aria-label$="[[label]]"
 				class="d2l-focusable"
@@ -201,6 +198,17 @@ Polymer-based web components for search
 				}
 			},
 
+			listeners: {
+				'focus': '_handleFocus',
+				'blur': '_handleBlur',
+				'mouseenter': '_handleMouseEnter',
+				'mouseleave': '_handleMouseLeave'
+			},
+
+			hostAttributes: {
+				'role': 'search'
+			},
+
 			_keyCodes: {
 				ENTER: 13
 			},
@@ -209,28 +217,6 @@ Polymer-based web components for search
 				if (this.value !== undefined && this.value !== null) {
 					this._setLastSearchValue(this.value);
 				}
-				this._handleFocus = this._handleFocus.bind(this);
-				this._handleBlur = this._handleBlur.bind(this);
-				this._handleMouseEnter = this._handleMouseEnter.bind(this);
-				this._handleMouseLeave = this._handleMouseLeave.bind(this);
-			},
-
-			attached: function() {
-				Polymer.RenderStatus.afterNextRender(this, function() {
-					var elem = this._getContainer();
-					elem.addEventListener('focus', this._handleFocus, true);
-					elem.addEventListener('blur', this._handleBlur, true);
-					elem.addEventListener('mouseenter', this._handleMouseEnter, true);
-					elem.addEventListener('mouseleave', this._handleMouseLeave, true);
-				});
-			},
-
-			detached: function() {
-				var elem = this._getContainer();
-				elem.removeEventListener('focus', this._handleFocus, true);
-				elem.removeEventListener('blur', this._handleBlur, true);
-				elem.removeEventListener('mouseenter', this._handleMouseEnter, true);
-				elem.removeEventListener('mouseleave', this._handleMouseLeave, true);
 			},
 
 			_computeShowSearch: function(lastSearchValue, value) {


### PR DESCRIPTION
I wasn't able to completely remove the container `<div>` since you can't add/remove CSS classes to the host (that I could figure out). So it's still needed for the focus/hover stuff.

But I was able to move the ARIA `search` role up to the host and move the event listeners there, which removed a bunch of code.